### PR TITLE
Allow re-ordering of attributes in the "Default Attributes" dialog

### DIFF
--- a/src/Dialogs/DefaultAttributesDialog.ts
+++ b/src/Dialogs/DefaultAttributesDialog.ts
@@ -227,7 +227,7 @@ export class DefaultAttributesDialog extends SettingsDialog<true> {
 
   private addUpDownBtnToRow(row: HTMLTableRowElement) {
     const tdUp = document.createElement('td');
-    this.addCustomButtonTo(tdUp, () => {
+    tdUp.appendChild(this.createUpDownBtn(() => {
       const table = row.parentElement as HTMLTableElement;
       const idx = row.rowIndex;
 
@@ -239,11 +239,11 @@ export class DefaultAttributesDialog extends SettingsDialog<true> {
 
         table.insertBefore(table.rows[idx], table.rows[idx-1]);
       }
-    }, Framework7Icons.Icons.control);
+    }, Framework7Icons.Icons.control));
     tdUp.title = 'Up';
 
     const tdDown = document.createElement('td');
-    this.addCustomButtonTo(tdDown, () => {
+    tdDown.appendChild(this.createUpDownBtn(() => {
       const table = row.parentElement as HTMLTableElement;
       const idx = row.rowIndex;
 
@@ -255,12 +255,30 @@ export class DefaultAttributesDialog extends SettingsDialog<true> {
 
         table.insertBefore(table.rows[idx], table.rows[idx+2] || null);
       }
-    }, Framework7Icons.Icons.control);
+    }, Framework7Icons.Icons.control));
     tdDown.title = 'Down';
     tdDown.style.transform = 'rotate(180deg)';
 
     row.insertBefore(tdUp, row.children[row.children.length - 1]);
     row.insertBefore(tdDown, row.children[row.children.length - 1]);
+  }
+
+  private createUpDownBtn(callback: () => void, icon?: string): HTMLElement {
+    const btn = mxUtils.button('', callback) as HTMLElement;
+    if (icon !== undefined) {
+      btn.innerHTML = icon;
+    } else {
+      btn.innerHTML = Framework7Icons.Icons.question;
+    }
+    btn.style.width = `24px`;
+    btn.style.height = `24px`;
+    btn.style.cursor = 'pointer';
+    if (btn.children[0] !== undefined) {
+      this.resizeSVG(btn.children[0], '100%', '100%');
+    }
+    btn.style.position = 'relative';
+    btn.style.display = 'inline-block';
+    return btn;
   }
 
   protected override removeRowFromForm(form: import('mxgraph').mxForm, row: HTMLTableRowElement): number | null {
@@ -274,6 +292,7 @@ export class DefaultAttributesDialog extends SettingsDialog<true> {
 
   private addIconPickerToRow(row: HTMLTableRowElement, callback: () => void, icon?: string): void {
     const td = document.createElement('td');
+    td.setAttribute('name', 'icon_picker');
     if (row.firstChild !== null) {
       row.insertBefore(td, row.firstChild);
     } else {

--- a/tests/attributes.spec.ts
+++ b/tests/attributes.spec.ts
@@ -118,7 +118,7 @@ test.describe('attributes and default attributes', () => {
     icon.click();
     await drawio.applyDialog();
     expect(path).toEqual(
-      await page.locator('table.properties').locator('tr').locator('td').locator('path').getAttribute('d')
+      await page.locator('table.properties').locator('tr').locator('td[name="icon_picker"]').locator('path').getAttribute('d')
     );
   });
 
@@ -172,7 +172,7 @@ test.describe('attributes and default attributes', () => {
     icon2.click();
     const path = await icon2.locator('path').getAttribute('d');
     await drawio.applyDialog();
-    expect(path).toEqual(await page.locator('td').locator('path').getAttribute('d'));
+    expect(path).toEqual(await page.locator('td[name="icon_picker"]').locator('path').getAttribute('d'));
 
   });
 


### PR DESCRIPTION
With the implemented changes, two buttons are now created for every row, which allow to change the order of the default attributes.

This PR fixes #15.