### PR TITLE
Show horizontal scrollbar if the table in the "Default Attributes" dialog overflows

### DIFF
--- a/src/Dialogs/DefaultAttributesDialog.ts
+++ b/src/Dialogs/DefaultAttributesDialog.ts
@@ -65,7 +65,7 @@ export class DefaultAttributesDialog extends SettingsDialog<true> {
     const addMoreGlobalAttributesTitle = this.getTitleDiv(mxResources.get('attackGraphs.addFurther'));
 
     const form = new mxForm('properties');
-    form.table.style.width = '100%';
+    form.table.style.cssText = 'width:100%;display:block;overflow-x:auto;white-space:nowrap;';
     this.attributeTable = form.table;
     this.addTextAreasTo(form, this.values);
 


### PR DESCRIPTION
Before this small code fix will be implemented, too long attribute names cause the table in the "Default Attributes" dialog to overflow and make it impossible to reach certain elements, e.g., the remove button. Below is an example attached:

<img alt="Screenshot 2022-03-11 094406" src="https://user-images.githubusercontent.com/8708114/157839312-78a99cc7-d84d-4976-a4f2-f6dc033f3783.png">

By introducing this small code fix, a scrollbar will now be shown, which allows to reach the elements hidden due to the mentioned overflow:

<img alt="Screenshot 2022-03-11 101304" src="https://user-images.githubusercontent.com/8708114/157839619-4f2babce-1592-4028-8503-eff853161e3f.png">