### PR TITLE
Decrease size of input fields

### DIFF
--- a/src/Dialogs/DefaultAttributesDialog.ts
+++ b/src/Dialogs/DefaultAttributesDialog.ts
@@ -205,14 +205,14 @@ export class DefaultAttributesDialog extends SettingsDialog<true> {
     const tdTextMin = document.createElement('td');
     const min = document.createElement('input');
     min.setAttribute('name', 'min');
-    min.style.width = '50pt';
+    min.style.width = '4ch';
     tdTextMin.innerHTML = 'Min:';
     tdMin.appendChild(min);
     const tdMax = document.createElement('td');
     const tdTextMax = document.createElement('td');
     const max = document.createElement('input');
     max.setAttribute('name', 'max');
-    max.style.width = '50pt';
+    max.style.width = '4ch';
     tdTextMax.innerHTML = 'Max:';
     tdMax.appendChild(max);
 

--- a/src/Dialogs/SettingsDialog.ts
+++ b/src/Dialogs/SettingsDialog.ts
@@ -105,7 +105,7 @@ export abstract class SettingsDialog<TValue> {
     const label = document.createElement('td');
     label.innerHTML = `${mxResources.get('attackGraphs.value')}:`;
     textArea.value = value;
-    textArea.style.width = '50pt';
+    textArea.style.width = '4ch';
     if (parentNode) {
       parentNode.removeChild(oldTextArea);
       parentNode.appendChild(textArea);


### PR DESCRIPTION
The width of input fields in the default attributes dialog is decreased to 4 characters.

Closes #39.