### PR TITLE
Highlight incoming & ougoing edges of selected nodes

### DIFF
--- a/src/Analysis/CellStyles.ts
+++ b/src/Analysis/CellStyles.ts
@@ -3,6 +3,7 @@ import { AttackGraphNodeShape } from '../AttackGraphNodeShape';
 
 export class CellStyles {
   cell: import('mxgraph').mxCell;
+  private selected = false;
 
   constructor(cell: import('mxgraph').mxCell) {
     this.cell = cell;
@@ -31,6 +32,9 @@ export class CellStyles {
     return 'shape' in styles && (styles['shape'] === AttackGraphNodeShape.ID || styles['shape'] === AttackGraphIconLegendShape.ID || styles['shape'] === 'or' || styles['shape'] === 'xor');
   }
 
+  setSelected(selected: boolean): void {
+    this.selected = selected;
+  }
 
   private encodeStyles(styles: { [key: string]: string }) {
     let style = '';
@@ -38,6 +42,12 @@ export class CellStyles {
       style += `${k}=${v};`;
     }
     return style;
+  }
+
+  renderHighlightedEdge(): void {
+    const styles = this.parseStyles();
+    styles['strokeWidth'] = '4';
+    this.cell.style = this.encodeStyles(styles);
   }
 
   renderFatEdge(): void {
@@ -55,7 +65,11 @@ export class CellStyles {
   updateEdgeStyle(): void {
     if ((this.cell.target !== null && this.cell.source !== null) &&
       (new CellStyles(this.cell.target).isAttackgraphCell() || new CellStyles(this.cell.source).isAttackgraphCell())) {
-      new CellStyles(this.cell).renderFatEdge();
+        if (this.selected) {
+          new CellStyles(this.cell).renderHighlightedEdge();
+        } else {
+          new CellStyles(this.cell).renderFatEdge();
+        }
     } else {
       new CellStyles(this.cell).resetEdge();
     }
@@ -71,7 +85,9 @@ export class CellStyles {
 
   updateConnectedEdgesStyle() {
     for (const edge of this.cell.edges) {
-      new CellStyles(edge).updateEdgeStyle();
+      const style = new CellStyles(edge);
+      style.setSelected(this.selected);
+      style.updateEdgeStyle();
     }
   }
 }

--- a/src/VertexHandler.ts
+++ b/src/VertexHandler.ts
@@ -3,6 +3,7 @@ import { EditAggregationFunctionDialog, EditComputedAttributesFunctionDialog } f
 import { AsyncWorker } from './AsyncUtils';
 import { AttributeRenderer } from './AttributeRenderer';
 import { AttackGraphSettings } from './AttackGraphSettings';
+import { CellStyles } from './Analysis/CellStyles';
 
 
 const IMAGE_WIDTH = 24;
@@ -81,12 +82,9 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
       // Highlight incoming and outgoing edges
       const cell = this.state.cell;
       if (cell.edges) {
-        for (const edge of cell.edges) {
-          let styles = edge.getStyle().split(';').filter(x => x !== '').map(x => x.split('='));
-          styles = styles.filter(x => !x.includes('strokeWidth'));
-          styles.push(['strokeWidth', '4']);
-          edge.setStyle(styles.map(x => x.join('=')).join(';') + ';');
-        }
+        const style = new CellStyles(cell);
+        style.setSelected(true);
+        style.updateConnectedEdgesStyle();
         ui.editor.graph.refresh();
       }
 
@@ -140,12 +138,9 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
       // Remove highlight of incoming and outgoing edges
       const cell = this.state.cell;
       if (cell.edges) {
-        for (const edge of cell.edges) {
-          let styles = edge.getStyle().split(';').filter(x => x !== '').map(x => x.split('='));
-          styles = styles.filter(x => !x.includes('strokeWidth'));
-          styles.push(['strokeWidth', '2']);
-          edge.setStyle(styles.map(x => x.join('=')).join(';') + ';');
-        }
+        const style = new CellStyles(cell);
+        style.setSelected(false);
+        style.updateConnectedEdgesStyle();
         ui.editor.graph.refresh();
       }
 

--- a/src/VertexHandler.ts
+++ b/src/VertexHandler.ts
@@ -80,13 +80,15 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
 
       // Highlight incoming and outgoing edges
       const cell = this.state.cell;
-      for (const edge of cell.edges) {
-        let styles = edge.getStyle().split(';').filter(x => x !== '').map(x => x.split('='));
-        styles = styles.filter(x => !x.includes('strokeWidth'));
-        styles.push(['strokeWidth', '4']);
-        edge.setStyle(styles.map(x => x.join('=')).join(';') + ';');
+      if (cell.edges) {
+        for (const edge of cell.edges) {
+          let styles = edge.getStyle().split(';').filter(x => x !== '').map(x => x.split('='));
+          styles = styles.filter(x => !x.includes('strokeWidth'));
+          styles.push(['strokeWidth', '4']);
+          edge.setStyle(styles.map(x => x.join('=')).join(';') + ';');
+        }
+        ui.editor.graph.refresh();
       }
-      ui.editor.graph.refresh();
 
       this.redrawHandles();
     }
@@ -137,13 +139,15 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
 
       // Remove highlight of incoming and outgoing edges
       const cell = this.state.cell;
-      for (const edge of cell.edges) {
-        let styles = edge.getStyle().split(';').filter(x => x !== '').map(x => x.split('='));
-        styles = styles.filter(x => !x.includes('strokeWidth'));
-        styles.push(['strokeWidth', '2']);
-        edge.setStyle(styles.map(x => x.join('=')).join(';') + ';');
+      if (cell.edges) {
+        for (const edge of cell.edges) {
+          let styles = edge.getStyle().split(';').filter(x => x !== '').map(x => x.split('='));
+          styles = styles.filter(x => !x.includes('strokeWidth'));
+          styles.push(['strokeWidth', '2']);
+          edge.setStyle(styles.map(x => x.join('=')).join(';') + ';');
+        }
+        ui.editor.graph.refresh();
       }
-      ui.editor.graph.refresh();
 
       this.functionHandles = null;
     }

--- a/src/VertexHandler.ts
+++ b/src/VertexHandler.ts
@@ -77,6 +77,17 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
     vertexHandlerInit.apply(this, rest);
     if (AttackGraphSettings.isAttackGraph(ui.editor.graph) && this.graph.getSelectionCount() === 1) {
       drawFunctionHandle(this);
+
+      // Highlight incoming and outgoing edges
+      const cell = this.state.cell;
+      for (const edge of cell.edges) {
+        let styles = edge.getStyle().split(';').filter(x => x !== '').map(x => x.split('='));
+        styles = styles.filter(x => !x.includes('strokeWidth'));
+        styles.push(['strokeWidth', '4']);
+        edge.setStyle(styles.map(x => x.join('=')).join(';') + ';');
+      }
+      ui.editor.graph.refresh();
+
       this.redrawHandles();
     }
   }
@@ -123,6 +134,16 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
           functionHandle.parentNode.removeChild(functionHandle);
         }
       }
+
+      // Remove highlight of incoming and outgoing edges
+      const cell = this.state.cell;
+      for (const edge of cell.edges) {
+        let styles = edge.getStyle().split(';').filter(x => x !== '').map(x => x.split('='));
+        styles = styles.filter(x => !x.includes('strokeWidth'));
+        styles.push(['strokeWidth', '2']);
+        edge.setStyle(styles.map(x => x.join('=')).join(';') + ';');
+      }
+      ui.editor.graph.refresh();
 
       this.functionHandles = null;
     }


### PR DESCRIPTION
This PR highlights incoming and outgoing edges of a selected node. The edges flowing in and out of the node are drawn thicker to ease identification of the aforementioned edges.

Fixes #58.