### PR TITLE
Add support to highlight critical paths

### DIFF
--- a/docs/aggregation_functions.md
+++ b/docs/aggregation_functions.md
@@ -19,26 +19,29 @@ The aggregation function dialog allows to specify a custom aggregation function 
 
 ### Relevant data types
 ```ts
-type ChildCellDataCollection = {
-  globalAttributes: GlobalAttributeDict,
-  childAttributes: ChildCellData[],
-  localAttributes: CellAttributes,
-}
+type KeyValuePairs = { [k: string]: string }
+type GlobalAttributeDict = { [name: string]: GlobalAttribute}
 
 type GlobalAttribute = {
   name: string,
   value: string,
   min: string,
-  max: string
-};
+  max: string,
+}
 
 type ChildCellData = {
-  edgeWeight: number,
-  attributes: CellChildAttributes,
+  edgeWeight: string | null,
+  attributes: KeyValuePairs,
   computedAttribute: string,
-};
+  id: string
+}
 
-type CellAttributes = { [k: string]: string };
+type ChildCellDataCollection = {
+  globalAttributes: GlobalAttributeDict,
+  childAttributes: ChildCellData[],
+  localAttributes: KeyValuePairs,
+  id: string
+}
 ```
 ### Example of an aggregation function accessing a child's attribute's value
 ```js

--- a/docs/computed_attributes_functions.md
+++ b/docs/computed_attributes_functions.md
@@ -16,11 +16,7 @@ The computed attributes function dialog allows to specify a custom computed attr
 
 ### Relevant data types
 ```ts
-type CellDataCollection = {
-  globalAttributes: GlobalAttributeDict,
-  cellAttributes: KeyValuePairs,
-}
-
+type KeyValuePairs = { [k: string]: string }
 type GlobalAttributeDict = { [name: string]: GlobalAttribute}
 
 type GlobalAttribute = {
@@ -28,9 +24,12 @@ type GlobalAttribute = {
   value: string,
   min: string,
   max: string,
- }
+}
 
-type KeyValuePairs = { [k: string]: string };
+type CellDataCollection = {
+  globalAttributes: GlobalAttributeDict,
+  cellAttributes: KeyValuePairs,
+}
 ```
 
 ### Example of a computed attributes function accessing the value of a cell attribute

--- a/src/Analysis/CellStyles.ts
+++ b/src/Analysis/CellStyles.ts
@@ -111,8 +111,8 @@ export class CellStyles {
 
   updateConnectedEdgesStyle(selected: boolean, shallMark: boolean) {
     if (this.cell.edges) {
-      const values = (shallMark) ? AttributeRenderer.nodeAttributes(this.cell).getAggregatedCellValues() : null;
-      const markings = (values && '_marking' in values) ? values['_marking'].split(';') : null;
+      const values = AttributeRenderer.nodeAttributes(this.cell).getAggregatedCellValues();
+      const markings = ('_marking' in values) ? values['_marking'].split(';') : null;
 
       for (const edge of this.cell.edges) {
         const style = new CellStyles(edge);
@@ -123,9 +123,11 @@ export class CellStyles {
             && edge.source
             && edge.target.id !== this.cell.id
             && edge.source.id === this.cell.id) {
-          const mark = (shallMark && markings && markings.includes(edge.target.id)) as boolean;
-          style.setMarked(mark);
-          new CellStyles(edge.target).updateConnectedEdgesStyle(false, mark);
+          const mark = (markings && markings.includes(edge.target.id)) as boolean;
+          if (mark) {
+            style.setMarked(shallMark);
+            new CellStyles(edge.target).updateConnectedEdgesStyle(false, shallMark);
+          }
         }
 
         style.updateEdgeStyle();

--- a/src/AttributeRenderer.ts
+++ b/src/AttributeRenderer.ts
@@ -68,7 +68,8 @@ export class AttributeRenderer {
     const aggregatedValues = await this.aggregateAttributes({
       globalAttributes: globalDefaultAttributesDict,
       childAttributes: childValues,
-      localAttributes
+      localAttributes: localAttributes,
+      id: cell.getCellId()
     }, aggregationFunction, worker);
     cell.setAggregatedCellValues(aggregatedValues);
 
@@ -116,7 +117,7 @@ export class AttributeRenderer {
       const cellValues = target.getCellValues();
       const aggregatedValues = target.getAggregatedCellValues();
       const computedAttribute = Object.values(target.getComputedAttributesForCell() || {})[0];
-      return { edgeWeight, attributes: { ...cellValues, ...aggregatedValues }, computedAttribute: computedAttribute };
+      return { edgeWeight, attributes: { ...cellValues, ...aggregatedValues }, computedAttribute: computedAttribute, id: target.getCellId() };
     }) || [];
   }
 

--- a/src/Model/index.ts
+++ b/src/Model/index.ts
@@ -8,6 +8,7 @@ export type ChildCellDataCollection = {
   globalAttributes: GlobalAttributeDict,
   childAttributes: ChildCellData[],
   localAttributes: KeyValuePairs,
+  id: string
 };
 
 export type GlobalAttributeDict = { [name: string]: {name: string, value: string, min: string, max: string} }
@@ -15,6 +16,7 @@ export type ChildCellData = {
   edgeWeight: string | null,
   attributes: KeyValuePairs,
   computedAttribute: string,
+  id: string
 };
 
 export type GlobalAttribute = {

--- a/src/VertexHandler.ts
+++ b/src/VertexHandler.ts
@@ -83,8 +83,7 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
       const cell = this.state.cell;
       if (cell.edges) {
         const style = new CellStyles(cell);
-        style.setSelected(true);
-        style.updateConnectedEdgesStyle();
+        style.updateConnectedEdgesStyle(true, true);
         ui.editor.graph.refresh();
       }
 
@@ -139,8 +138,7 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
       const cell = this.state.cell;
       if (cell.edges) {
         const style = new CellStyles(cell);
-        style.setSelected(false);
-        style.updateConnectedEdgesStyle();
+        style.updateConnectedEdgesStyle(false, false);
         ui.editor.graph.refresh();
       }
 

--- a/templates/AttackGraphTemplate_TS50701.drawio
+++ b/templates/AttackGraphTemplate_TS50701.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" modified="2022-07-11T09:05:02.157Z" agent="5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/19.0.2 Chrome/102.0.5005.63 Electron/19.0.3 Safari/537.36" etag="2wNVzUWhh01jnN3M-eUD" compressed="false" version="19.0.2" type="device">
+<mxfile host="Electron" modified="2022-08-10T14:59:36.729Z" agent="5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/19.0.2 Chrome/102.0.5005.63 Electron/19.0.3 Safari/537.36" etag="e9V6mLg8rtl42Bk1PRIL" compressed="false" version="19.0.2" type="device">
   <diagram id="zNMCXYOBYckHPa1j1fsk" name="Seite-1">
-    <mxGraphModel dx="469" dy="281" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+    <mxGraphModel dx="904" dy="568" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <object tooltip="" id="0">
           <ag_global_attributes>
@@ -11,8 +11,8 @@
           <ag_attributes />
           <ag_computed_attributes />
           <ag_aggregation_functions>
-            <ag_aggregation_function name="default" id="6b1d22791hih8" default="consequence;activity_w;or" fn="function (collection) { &#xa;    var worstNodeLike = collection.childAttributes[0]; &#xa;    var worstNodeRisk = collection.childAttributes[0]; &#xa;    var maxLikelihood = 0; &#xa;    var maxRisk = &quot;L&quot;; &#xa;    var maxImpactLike = 0; &#xa;    var maxImpactRisk = null; &#xa;    var hadEdgeWeight = false; &#xa;    var riskMatrix = { &#xa;        &quot;D&quot;: [&quot;L&quot;, &quot;L&quot;, &quot;L&quot;, &quot;M&quot;, &quot;S&quot;], &#xa;        &quot;C&quot;: [&quot;L&quot;, &quot;L&quot;, &quot;M&quot;, &quot;S&quot;, &quot;H&quot;], &#xa;        &quot;B&quot;: [&quot;L&quot;, &quot;M&quot;, &quot;S&quot;, &quot;H&quot;, &quot;H&quot;], &#xa;        &quot;A&quot;: [&quot;M&quot;, &quot;S&quot;, &quot;H&quot;, &quot;H&quot;, &quot;V&quot;] &#xa;    }; &#xa;    var edgeWeights = [&quot;D&quot;, &quot;C&quot;, &quot;B&quot;, &quot;A&quot;]; &#xa; &#xa;    /* &#xa;    Returns &#xa;        - &lt; 0 if risk1 &lt; risk2 &#xa;        - = 0 if risk1 = risk2 &#xa;        - &gt; 0 if risk1 &gt; risk2 &#xa;        - null if either risk is not in [&quot;L&quot;, &quot;M&quot;, &quot;S&quot;, &quot;H&quot;, &quot;V&quot;] &#xa;    */ &#xa;    var compareRisk = function(risk1, risk2) { &#xa;        var values = [&quot;L&quot;, &quot;M&quot;, &quot;S&quot;, &quot;H&quot;, &quot;V&quot;]; &#xa;        var index_risk1 = values.indexOf(risk1); &#xa;        var index_risk2 = values.indexOf(risk2); &#xa; &#xa;        if (index_risk1 == -1 || index_risk2 == -1) { &#xa;            return null; &#xa;        } &#xa;        return index_risk1 - index_risk2; &#xa;    } &#xa;    collection.childAttributes.forEach(function(child) { &#xa;        var likelihood = 0; &#xa; &#xa;        if (&quot;_likelihood&quot; in child.attributes) { &#xa;            likelihood = child.attributes[&quot;_likelihood&quot;]; &#xa;        } else if (&quot;Exposure&quot; in child.attributes &amp;&amp; &quot;Vulnerability&quot; in child.attributes) { &#xa;            likelihood = parseInt(child.attributes[&quot;Exposure&quot;]) + parseInt(child.attributes[&quot;Vulnerability&quot;]) - 1; &#xa;        } &#xa; &#xa;        if (edgeWeights.indexOf(child.edgeWeight) &gt;= 0) { &#xa;            hadEdgeWeight = true; &#xa;            var reduceImpact = 0; &#xa;            if (&quot;_impact&quot; in child.attributes) { &#xa;                reduceImpact = child.attributes[&quot;_impact&quot;]; &#xa;            } else if (&quot;Impact&quot; in child.attributes) { &#xa;                reduceImpact = child.attributes[&quot;Impact&quot;]; &#xa;            } &#xa;            var idxImpact = Math.max(Math.min(edgeWeights.indexOf(child.edgeWeight) - reduceImpact, edgeWeights.length), 0); &#xa;            var impact = edgeWeights[idxImpact]; &#xa;            var risk = riskMatrix[impact][likelihood - 1]; &#xa;            if (!maxImpactRisk) { &#xa;                maxImpactRisk = impact; &#xa;            } &#xa;            if (compareRisk(risk, maxRisk) &gt; 0) { &#xa;                maxRisk = risk; &#xa;                maxLikelihood = likelihood; &#xa;                maxImpactRisk = impact; &#xa;                worstNodeRisk = child; &#xa;            } &#xa;        } else { &#xa;            if (likelihood &gt; maxLikelihood) { &#xa;                maxLikelihood = likelihood; &#xa;                worstNodeLike = child; &#xa;            } &#xa;            if (&quot;_impact&quot; in child.attributes) { &#xa;                maxImpactLike = Math.max(maxImpactLike, child.attributes[&quot;_impact&quot;]); &#xa;            } else if (&quot;Impact&quot; in child.attributes) { &#xa;                maxImpactLike = Math.max(maxImpactLike, child.attributes[&quot;Impact&quot;]); &#xa;            } &#xa;        } &#xa;    }); &#xa; &#xa;    if(hadEdgeWeight) { &#xa;        var result = {&quot;_risk&quot;: maxRisk}; &#xa;        if (maxImpactRisk) { &#xa;            result.Impact = maxImpactRisk; &#xa;        } &#xa;        return result; &#xa;    } else { &#xa;        var result = {&quot;_likelihood&quot;: maxLikelihood}; &#xa;        if (maxImpactLike) { &#xa;            result._impact = maxImpactLike; &#xa;        } &#xa;        return result; &#xa;    } &#xa;} &#xa;" />
-            <ag_aggregation_function name="AND" id="gf0d4f199018" default="and" fn="function(collection){&#xa;&#xa;    var product = 1;&#xa;    var n = 0;&#xa;&#xa;    collection.childAttributes.forEach(function(child){        &#xa;        var likelihood = (&quot;_likelihood&quot; in child.attributes)&#xa;            ? parseInt(child.attributes[&quot;_likelihood&quot;])&#xa;            : parseInt(child.attributes[&quot;Exposure&quot;]) + parseInt(child.attributes[&quot;Vulnerability&quot;]) - 1;&#xa;        n += 1;&#xa;        product *= likelihood;&#xa;    });&#xa;&#xa;    product = Math.ceil(product / Math.pow(5, n-1));&#xa;    result = {&quot;_likelihood&quot;: product};&#xa;&#xa;    // Calc impact&#xa;    var impact = 0;&#xa;    collection.childAttributes.forEach(function(child){&#xa;        if (&#39;_impact&#39; in child.attributes) {&#xa;            impact = Math.max(child.attributes[&#39;_impact&#39;], impact);&#xa;        } else if (&#39;Impact&#39; in child.attributes) {&#xa;            impact = Math.max(child.attributes[&#39;Impact&#39;], impact);&#xa;        }&#xa;    });&#xa;    if (impact) {&#xa;        result._impact = impact;&#xa;    }&#xa;&#xa;    return result;&#xa;}" />
+            <ag_aggregation_function name="default" id="6b1d22791hih8" default="consequence;activity_w;or" fn="function (collection) { &#xa;    var worstNodeLike = collection.childAttributes[0]; &#xa;    var worstNodeRisk = collection.childAttributes[0]; &#xa;    var maxLikelihood = 0; &#xa;    var maxRisk = &quot;L&quot;; &#xa;    var maxImpactLike = 0; &#xa;    var maxImpactRisk = null; &#xa;    var hadEdgeWeight = false; &#xa;    var riskMatrix = { &#xa;        &quot;D&quot;: [&quot;L&quot;, &quot;L&quot;, &quot;L&quot;, &quot;M&quot;, &quot;S&quot;], &#xa;        &quot;C&quot;: [&quot;L&quot;, &quot;L&quot;, &quot;M&quot;, &quot;S&quot;, &quot;H&quot;], &#xa;        &quot;B&quot;: [&quot;L&quot;, &quot;M&quot;, &quot;S&quot;, &quot;H&quot;, &quot;H&quot;], &#xa;        &quot;A&quot;: [&quot;M&quot;, &quot;S&quot;, &quot;H&quot;, &quot;H&quot;, &quot;V&quot;] &#xa;    }; &#xa;    var edgeWeights = [&quot;D&quot;, &quot;C&quot;, &quot;B&quot;, &quot;A&quot;]; &#xa; &#xa;    /* &#xa;    Returns &#xa;        - &lt; 0 if risk1 &lt; risk2 &#xa;        - = 0 if risk1 = risk2 &#xa;        - &gt; 0 if risk1 &gt; risk2 &#xa;        - null if either risk is not in [&quot;L&quot;, &quot;M&quot;, &quot;S&quot;, &quot;H&quot;, &quot;V&quot;] &#xa;    */ &#xa;    var compareRisk = function(risk1, risk2) { &#xa;        var values = [&quot;L&quot;, &quot;M&quot;, &quot;S&quot;, &quot;H&quot;, &quot;V&quot;]; &#xa;        var index_risk1 = values.indexOf(risk1); &#xa;        var index_risk2 = values.indexOf(risk2); &#xa; &#xa;        if (index_risk1 == -1 || index_risk2 == -1) { &#xa;            return null; &#xa;        } &#xa;        return index_risk1 - index_risk2; &#xa;    } &#xa;    collection.childAttributes.forEach(function(child) { &#xa;        var likelihood = 0; &#xa; &#xa;        if (&quot;_likelihood&quot; in child.attributes) { &#xa;            likelihood = child.attributes[&quot;_likelihood&quot;]; &#xa;        } else if (&quot;Exposure&quot; in child.attributes &amp;&amp; &quot;Vulnerability&quot; in child.attributes) { &#xa;            likelihood = parseInt(child.attributes[&quot;Exposure&quot;]) + parseInt(child.attributes[&quot;Vulnerability&quot;]) - 1; &#xa;        } &#xa; &#xa;        if (edgeWeights.indexOf(child.edgeWeight) &gt;= 0) { &#xa;            hadEdgeWeight = true; &#xa;            var reduceImpact = 0; &#xa;            if (&quot;_impact&quot; in child.attributes) { &#xa;                reduceImpact = child.attributes[&quot;_impact&quot;]; &#xa;            } else if (&quot;Impact&quot; in child.attributes) { &#xa;                reduceImpact = child.attributes[&quot;Impact&quot;]; &#xa;            } &#xa;            var idxImpact = Math.max(Math.min(edgeWeights.indexOf(child.edgeWeight) - reduceImpact, edgeWeights.length), 0); &#xa;            var impact = edgeWeights[idxImpact]; &#xa;            var risk = riskMatrix[impact][likelihood - 1]; &#xa;            if (!maxImpactRisk) { &#xa;                maxImpactRisk = impact; &#xa;            } &#xa;            if (compareRisk(risk, maxRisk) &gt; 0) { &#xa;                maxRisk = risk; &#xa;                maxLikelihood = likelihood; &#xa;                maxImpactRisk = impact; &#xa;                worstNodeRisk = child; &#xa;            } &#xa;        } else { &#xa;            if (likelihood &gt; maxLikelihood) { &#xa;                maxLikelihood = likelihood; &#xa;                worstNodeLike = child; &#xa;            } &#xa;            if (&quot;_impact&quot; in child.attributes) { &#xa;                maxImpactLike = Math.max(maxImpactLike, child.attributes[&quot;_impact&quot;]); &#xa;            } else if (&quot;Impact&quot; in child.attributes) { &#xa;                maxImpactLike = Math.max(maxImpactLike, child.attributes[&quot;Impact&quot;]); &#xa;            } &#xa;        } &#xa;    }); &#xa; &#xa;    if(hadEdgeWeight) { &#xa;        var result = {&quot;_risk&quot;: maxRisk, &quot;_marking&quot;: worstNodeRisk.id}; &#xa;        if (maxImpactRisk) { &#xa;            result.Impact = maxImpactRisk; &#xa;        } &#xa;        return result; &#xa;    } else { &#xa;        var result = {&quot;_likelihood&quot;: maxLikelihood, &quot;_marking&quot;: worstNodeLike.id}; &#xa;        if (maxImpactLike) { &#xa;            result._impact = maxImpactLike; &#xa;        } &#xa;        return result; &#xa;    } &#xa;} &#xa;" />
+            <ag_aggregation_function name="AND" id="gf0d4f199018" default="and" fn="function(collection){&#xa;&#xa;    var product = 1;&#xa;    var n = 0;&#xa;    var ids = [];&#xa;&#xa;    collection.childAttributes.forEach(function(child){        &#xa;        var likelihood = (&quot;_likelihood&quot; in child.attributes)&#xa;            ? parseInt(child.attributes[&quot;_likelihood&quot;])&#xa;            : parseInt(child.attributes[&quot;Exposure&quot;]) + parseInt(child.attributes[&quot;Vulnerability&quot;]) - 1;&#xa;        n += 1;&#xa;        product *= likelihood;&#xa;        &#xa;        ids.push(child.id);&#xa;    });&#xa;&#xa;    product = Math.ceil(product / Math.pow(5, n-1));&#xa;    result = {&quot;_likelihood&quot;: product, &quot;_marking&quot;: ids.join(&quot;;&quot;)};&#xa;&#xa;    // Calc impact&#xa;    var impact = 0;&#xa;    collection.childAttributes.forEach(function(child){&#xa;        if (&#39;_impact&#39; in child.attributes) {&#xa;            impact = Math.max(child.attributes[&#39;_impact&#39;], impact);&#xa;        } else if (&#39;Impact&#39; in child.attributes) {&#xa;            impact = Math.max(child.attributes[&#39;Impact&#39;], impact);&#xa;        }&#xa;    });&#xa;    if (impact) {&#xa;        result._impact = impact;&#xa;    }&#xa;&#xa;    return result;&#xa;}" />
             <ag_aggregation_function name="Leaf Node" id="jig393i6f4dh9" default="activity_g;activity_y" fn="function(collection){ &#xa;    result = {}; &#xa;    for (localAttribute in collection.localAttributes){ &#xa;        value = parseInt(collection.localAttributes[localAttribute]); &#xa;        collection.childAttributes.forEach(function(child){ &#xa;            if (localAttribute in child.attributes) { &#xa;                v = parseInt(child.attributes[localAttribute]); &#xa;                if (!isNaN(v)) { &#xa;                    value -= v; &#xa;                } &#xa;            } &#xa;        }); &#xa;        if (localAttribute in collection.globalAttributes){ &#xa;            value = Math.max(collection.globalAttributes[localAttribute].min, Math.min(collection.globalAttributes[localAttribute].max, value)); &#xa;        } &#xa;        result[localAttribute] = value; &#xa;    }&#xa;    &#xa;    // Calculate impact&#xa;    var impact = 0;&#xa;    collection.childAttributes.forEach(function(child){&#xa;        if (&#39;Impact&#39; in child.attributes) {&#xa;            impact = Math.max(child.attributes[&#39;Impact&#39;], impact);&#xa;        }&#xa;    });&#xa;    if (impact) {&#xa;        result._impact = impact;&#xa;    }&#xa;    &#xa;    return result; &#xa;}" />
           </ag_aggregation_functions>
           <ag_computed_attributes_functions>
@@ -42,7 +42,7 @@
         <object label="Consequence" id="746xIQmpy0CREaIetn3r-3">
           <ag_aggregation_function_reference ag_aggregation_function_reference="6b1d22791hih8" />
           <ag_computed_attributes_function_reference ag_computed_attributes_function_reference="dbg60ff69g9a" />
-          <ag_attributes _risk="M" Impact="B" />
+          <ag_attributes _risk="M" _marking="746xIQmpy0CREaIetn3r-6" Impact="B" />
           <ag_computed_attributes default="M" />
           <mxCell style="shape=attackgraphs.node;rounded=1" parent="1" vertex="1">
             <mxGeometry x="160" y="150" width="150" height="75" as="geometry" />
@@ -65,7 +65,7 @@
         <object label="Attack Step" id="746xIQmpy0CREaIetn3r-6">
           <ag_aggregation_function_reference ag_aggregation_function_reference="6b1d22791hih8" />
           <ag_computed_attributes_function_reference ag_computed_attributes_function_reference="dbg60ff69g9a" />
-          <ag_attributes _likelihood="2" _impact="1" />
+          <ag_attributes _likelihood="2" _marking="746xIQmpy0CREaIetn3r-7" _impact="1" />
           <ag_computed_attributes default="2" />
           <mxCell style="shape=attackgraphs.node;" parent="1" vertex="1">
             <mxGeometry x="315" y="330" width="150" height="75" as="geometry" />
@@ -90,7 +90,7 @@
         <object label="Sup-Step 2" id="746xIQmpy0CREaIetn3r-9">
           <ag_aggregation_function_reference ag_aggregation_function_reference="6b1d22791hih8" />
           <ag_computed_attributes_function_reference ag_computed_attributes_function_reference="dbg60ff69g9a" />
-          <ag_attributes _likelihood="1" _impact="1" />
+          <ag_attributes _likelihood="1" _marking="746xIQmpy0CREaIetn3r-17" _impact="1" />
           <ag_computed_attributes default="1" />
           <mxCell style="shape=attackgraphs.node;" parent="1" vertex="1">
             <mxGeometry x="450" y="510" width="150" height="75" as="geometry" />
@@ -158,7 +158,7 @@
         </object>
         <object id="746xIQmpy0CREaIetn3r-17">
           <ag_aggregation_function_reference ag_aggregation_function_reference="gf0d4f199018" />
-          <ag_attributes _likelihood="1" _impact="1" />
+          <ag_attributes _likelihood="1" _marking="746xIQmpy0CREaIetn3r-11;746xIQmpy0CREaIetn3r-14;W0IZxeYySRvhsjoWCsxC-1" _impact="1" />
           <ag_computed_attributes />
           <mxCell style="shape=or;whiteSpace=wrap;html=1;rotation=-90;" parent="1" vertex="1">
             <mxGeometry x="502.5" y="630" width="45" height="60" as="geometry" />
@@ -188,7 +188,7 @@
         <object label="Consequence" id="746xIQmpy0CREaIetn3r-21">
           <ag_aggregation_function_reference ag_aggregation_function_reference="6b1d22791hih8" />
           <ag_computed_attributes_function_reference ag_computed_attributes_function_reference="dbg60ff69g9a" />
-          <ag_attributes _risk="L" Impact="C" />
+          <ag_attributes _risk="L" _marking="W0IZxeYySRvhsjoWCsxC-5" Impact="C" />
           <ag_computed_attributes default="L" />
           <mxCell style="shape=attackgraphs.node;rounded=1" parent="1" vertex="1">
             <mxGeometry x="470" y="150" width="150" height="75" as="geometry" />
@@ -215,7 +215,7 @@
         <object label="Sub-Step 23" id="W0IZxeYySRvhsjoWCsxC-1">
           <ag_aggregation_function_reference ag_aggregation_function_reference="6b1d22791hih8" />
           <ag_computed_attributes_function_reference ag_computed_attributes_function_reference="dbg60ff69g9a" />
-          <ag_attributes _likelihood="5" />
+          <ag_attributes _likelihood="5" _marking="W0IZxeYySRvhsjoWCsxC-3" />
           <ag_computed_attributes default="5" />
           <mxCell style="shape=attackgraphs.node;" parent="1" vertex="1">
             <mxGeometry x="140" y="760" width="150" height="75" as="geometry" />
@@ -237,13 +237,17 @@
             <mxGeometry relative="1" as="geometry" />
           </mxCell>
         </object>
-        <mxCell id="_UFam-vNQ3AWC2Eo_QhS-1" value="" style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeWidth=2;startArrow=diamondThin;startFill=1;endArrow=none;endFill=0;" edge="1" parent="1" source="W0IZxeYySRvhsjoWCsxC-5" target="W0IZxeYySRvhsjoWCsxC-8">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
+        <object label="" id="_UFam-vNQ3AWC2Eo_QhS-1">
+          <ag_attributes />
+          <ag_computed_attributes />
+          <mxCell style="rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeWidth=2;startArrow=diamondThin;startFill=1;endArrow=none;endFill=0;" parent="1" source="W0IZxeYySRvhsjoWCsxC-5" target="W0IZxeYySRvhsjoWCsxC-8" edge="1">
+            <mxGeometry relative="1" as="geometry" />
+          </mxCell>
+        </object>
         <object label="" id="W0IZxeYySRvhsjoWCsxC-5">
           <ag_aggregation_function_reference ag_aggregation_function_reference="6b1d22791hih8" />
           <ag_computed_attributes_function_reference ag_computed_attributes_function_reference="ag_none_function" />
-          <ag_attributes _likelihood="2" _impact="2" />
+          <ag_attributes _likelihood="2" _marking="746xIQmpy0CREaIetn3r-6" _impact="2" />
           <ag_computed_attributes />
           <mxCell style="shape=attackgraphs.node;" parent="1" vertex="1">
             <mxGeometry x="460" y="275" width="10" height="10" as="geometry" />


### PR DESCRIPTION
This PR introduces a feature to highlight critical paths in an attack graph. Aggregtation functions can set a hidden attribute `_marking` with the ID of the child node to mark the edge from the node to the specified child node. Therefore, the collection object passed to the aggregation functions now includes the ID of all child nodes and the ID of the node itself.

Markings are only shown if a node is selected. Additionally, it only shows the critical path from the selected node "downwards". The following shows how an examplary marking looks when selecting a node:
<img width="485" alt="Attack graph with a critical path marked" src="https://user-images.githubusercontent.com/8708114/184080413-0b5c7b7d-3a7a-4571-886f-d638d9f8ad2e.png">

The aggregation functions for the TS 50701 template were updated to include the `_marking` attribute in aggregations. For the `AND` function all outgoing edges are marked because it doesn't make sense to mark a specific child node as critical for the worst likelihood/risk. Hence, all outgoing edges are marked to show also the influence of critical nodes below an `AND` node:
<img width="485" alt="Screenshot 2022-08-10 165855" src="https://user-images.githubusercontent.com/8708114/184081422-9202f0f1-0f8b-4a20-a13f-b7228f2f4301.png">

**Note**: The aggregation functions for the RKL template shall be updated before merging this PR.

Closes #57.

