### PR TITLE
Enhance test environment

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,10 +20,10 @@ jobs:
     - run: npm run build --if-present
     - name: Create customized version of draw.io
       run: |
-       docker build -t drawio -f docs/Dockerfile .
-       id=$(docker run --rm -d --entrypoint "" drawio tail -f /dev/null)
-       docker cp $id:/usr/local/tomcat/webapps/draw docs/app
-       docker stop $id
+       npm run docker
+       npm run start
+       docker cp drawio:/usr/local/tomcat/webapps/draw docs/app
+       npm run stop
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.2.3
       with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,16 +21,17 @@ jobs:
     - run: npm run lint
     - name: Install Playwright
       run: npx playwright install --with-deps
-    - name: Create Docker image for Playwright Tests
+    - name: Create Docker image for Playwright tests
       run: npm run docker
     - name: Run Playwright tests
-      run: npx playwright test --project chrome
+      run: npm run test
     - uses: actions/upload-artifact@v2
       if: always()
       with:
         name: playwright-test-results
         path: test-results/
     - name: Stop webserver
+      if: always()
       run: npm run stop
     - name: Archive compiled plugin
       uses: actions/upload-artifact@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,6 +21,8 @@ jobs:
     - run: npm run lint
     - name: Install Playwright
       run: npx playwright install --with-deps
+    - name: Create Docker image for Playwright Tests
+      run: npm run docker
     - name: Run Playwright tests
       run: npx playwright test --project chrome
     - uses: actions/upload-artifact@v2
@@ -28,6 +30,8 @@ jobs:
       with:
         name: playwright-test-results
         path: test-results/
+    - name: Stop webserver
+      run: npm run stop
     - name: Archive compiled plugin
       uses: actions/upload-artifact@v2
       with:

--- a/README.md
+++ b/README.md
@@ -14,11 +14,19 @@ Please find the detailed documentation [here](https://incyde-gmbh.github.io/draw
 
 ## Development
 
-This is a standard npm project using Typescript to produce a single script artifact under `dist/attackgraphs.js`.
+This is a standard npm project using Typescript to produce a single script artifact under `dist/attackgraphs.js`. Use `npm install` and `npm run build` to download all dependencies and build the plugin.
 
-Use `npm install` and `npm start`, to compile the plugin and start a development web server.
+To start a development web server, you need Docker installed. Use `npm run docker` to build the Docker image.
+After you built the plugin via `npm run build` or `npm run watch`, use `npm start` to deploy a container with the draw.io web app and the plugin installed.
 
-Then, open [http://localhost:8000](http://localhost:8000) and configure the plugin (Extras > Plugins... > Add... > Custom... > `http://localhost:8000/attackgraphs.js` > Add > Apply > Reload).
+Then, open [http://localhost:8000](http://localhost:8000) and configure the plugin (Extras > Plugins... > Add... > Custom... > `plugins/attackgraphs.js` > Add > Apply > Reload).
+
+*Note for Windows: the npm scripts are written for bash. However, npm uses `cmd.exe` by default.
+If you have [git for windows](https://git-scm.com/download/win) installed, you can use the following command to set bash as the default shell for scripts:*
+
+```
+npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"
+```
 
 ### draw.io Desktop
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM jgraph/drawio:20.3.7
+FROM jgraph/drawio:20.2.8
 
 RUN sed -i '/<template url/d' $CATALINA_HOME/webapps/draw/templates/index.xml
 RUN sed -i 's|</templates>|<template url="basic/attackgraph_RKL.xml" title="attackGraphs.attackGraph_RKL" libs="general;attackGraphs.attackGraphs" tags="attackGraphs.attackGraphs"/>\n<template url="basic/attackgraph_TS50701.xml" title="attackGraphs.attackGraph_TS50701" libs="general;attackGraphs.attackGraphs" tags="attackGraphs.attackGraphs"/>\n</templates>|g' $CATALINA_HOME/webapps/draw/templates/index.xml
@@ -11,7 +11,8 @@ ENV DRAWIO_BASE_URL=https://incyde-gmbh.github.io/drawio-plugin-attackgraphs/app
 ENV DRAWIO_CONFIG="{\"plugins\": [\"plugins/attackgraphs.js\"]}"
 
 # Activate custom plugins (TODO: Replace if base image has an option to activate custom plugins)
-RUN sed -i '38a\echo "window.ALLOW_CUSTOM_PLUGINS = true;" >> \$CATALINA_HOME/webapps/draw/js/PreConfig.js' /docker-entrypoint.sh
+# Uncomment when custom plugins are again automatically loaded via DRAWIO_CONFIG
+# RUN sed -i '38a\echo "window.ALLOW_CUSTOM_PLUGINS = true;" >> \$CATALINA_HOME/webapps/draw/js/PreConfig.js' /docker-entrypoint.sh
 
 # Configure draw.io
 RUN /docker-entrypoint.sh

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,21 +1,14 @@
-FROM jgraph/drawio:20.3.5
-
-# Install plugin
-COPY dist/attackgraphs.js $CATALINA_HOME/webapps/draw/plugins/attackgraphs.js
-
-# Install diagram template
-COPY dist/templates/AttackGraphTemplate_RKL.drawio $CATALINA_HOME/webapps/draw/templates/basic/attackgraph_RKL.xml
-COPY dist/templates/AttackGraphTemplate_TS50701.drawio $CATALINA_HOME/webapps/draw/templates/basic/attackgraph_TS50701.xml
+FROM jgraph/drawio:20.3.7
 
 RUN sed -i '/<template url/d' $CATALINA_HOME/webapps/draw/templates/index.xml
-
 RUN sed -i 's|</templates>|<template url="basic/attackgraph_RKL.xml" title="attackGraphs.attackGraph_RKL" libs="general;attackGraphs.attackGraphs" tags="attackGraphs.attackGraphs"/>\n<template url="basic/attackgraph_TS50701.xml" title="attackGraphs.attackGraph_TS50701" libs="general;attackGraphs.attackGraphs" tags="attackGraphs.attackGraphs"/>\n</templates>|g' $CATALINA_HOME/webapps/draw/templates/index.xml
+
 # Lend an icon
 RUN cp $CATALINA_HOME/webapps/draw/templates/other/decision_tree.png $CATALINA_HOME/webapps/draw/templates/basic/attackgraph_RKL.png
 RUN cp $CATALINA_HOME/webapps/draw/templates/other/decision_tree.png $CATALINA_HOME/webapps/draw/templates/basic/attackgraph_TS50701.png
 
 ENV DRAWIO_BASE_URL=https://incyde-gmbh.github.io/drawio-plugin-attackgraphs/app
-ENV DRAWIO_CONFIG="{\"plugins\": [\"${DRAWIO_BASE_URL}/plugins/attackgraphs.js\"]}"
+ENV DRAWIO_CONFIG="{\"plugins\": [\"plugins/attackgraphs.js\"]}"
 
 # Activate custom plugins (TODO: Replace if base image has an option to activate custom plugins)
 RUN sed -i '38a\echo "window.ALLOW_CUSTOM_PLUGINS = true;" >> \$CATALINA_HOME/webapps/draw/js/PreConfig.js' /docker-entrypoint.sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,6 @@
 
 [Launch draw.io](app)
 
-(You must enable the plugin on first start-up via "Extras > Plugins... > Add... > Custom... > plugins/attackgraphs.js > Add > Ok > Apply". Reload the website afterwards.)
-
 ### Draw.io Desktop
 
 You can obtain the latest version of the plugin from here:

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 [Launch draw.io](app)
 
+(You must enable the plugin on first start-up via "Extras > Plugins... > Add... > Custom... > plugins/attackgraphs.js > Add > Ok > Apply". Reload the website afterwards.)
+
 ### Draw.io Desktop
 
 You can obtain the latest version of the plugin from here:

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "start": "webpack serve --mode=development",
+    "docker": "docker build -t drawio-plugin-attackgraphs:test -f docs/Dockerfile .",
+    "start": "docker run --rm -d -p 127.0.0.1:8000:8080 --name drawio --mount type=bind,src=$(pwd)/dist/attackgraphs.js,dst=/usr/local/tomcat/webapps/draw/plugins/attackgraphs.js --mount type=bind,src=$(pwd)/dist/templates/AttackGraphTemplate_RKL.drawio,dst=/usr/local/tomcat/webapps/draw/templates/basic/attackgraph_RKL.xml --mount type=bind,src=$(pwd)/dist/templates/AttackGraphTemplate_TS50701.drawio,dst=/usr/local/tomcat/webapps/draw/templates/basic/attackgraph_TS50701.xml drawio-plugin-attackgraphs:test",
+    "stop": "docker stop drawio",
     "build": "webpack --mode=production",
     "watch": "webpack --watch --mode=development",
     "lint": "eslint src --ext .ts --max-warnings=0",
-    "test": "playwright test --project chromium"
+    "test": "playwright test --project chrome"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "docker": "docker build -t drawio-plugin-attackgraphs:test -f docs/Dockerfile .",
-    "start": "docker run --rm -d -p 127.0.0.1:8000:8080 --name drawio --mount type=bind,src=$(pwd)/dist/attackgraphs.js,dst=/usr/local/tomcat/webapps/draw/plugins/attackgraphs.js --mount type=bind,src=$(pwd)/dist/templates/AttackGraphTemplate_RKL.drawio,dst=/usr/local/tomcat/webapps/draw/templates/basic/attackgraph_RKL.xml --mount type=bind,src=$(pwd)/dist/templates/AttackGraphTemplate_TS50701.drawio,dst=/usr/local/tomcat/webapps/draw/templates/basic/attackgraph_TS50701.xml drawio-plugin-attackgraphs:test",
+    "start": "docker run --rm -d -p 127.0.0.1:8000:8080 --name drawio --mount type=bind,src=$(pwd)/dist/attackgraphs.js,dst=/usr/local/tomcat/webapps/draw/plugins/attackgraphs.js --mount type=bind,src=$(pwd)/dist/attackgraphs.js.map,dst=/usr/local/tomcat/webapps/draw/plugins/attackgraphs.js.map --mount type=bind,src=$(pwd)/dist/templates/AttackGraphTemplate_RKL.drawio,dst=/usr/local/tomcat/webapps/draw/templates/basic/attackgraph_RKL.xml --mount type=bind,src=$(pwd)/dist/templates/AttackGraphTemplate_TS50701.drawio,dst=/usr/local/tomcat/webapps/draw/templates/basic/attackgraph_TS50701.xml drawio-plugin-attackgraphs:test",
     "stop": "docker stop drawio",
     "build": "webpack --mode=production",
     "watch": "webpack --watch --mode=development",

--- a/tests/attributes.spec.ts
+++ b/tests/attributes.spec.ts
@@ -52,6 +52,10 @@ test.describe('attributes and default attributes', () => {
     await page.locator('.mxPopupMenu').locator('text="Save"').click();
     await page.locator('text=Browser').click();
 
+    // Wait to be sure that the file was saved in the browser
+    // TODO: Replace with wait for selector (spinning wheel) to be hidden
+    await page.waitForTimeout(3000);
+
     await page.goto('/');
     await page.locator('text="File"').first().waitFor();
 

--- a/tests/base.ts
+++ b/tests/base.ts
@@ -25,7 +25,7 @@ export const test = base.extend<{drawio: DrawioPage}>({
         "customFonts": [],
         "libraries": "general;uml;er;bpmn;flowchart;basic;arrows2",
         "customLibraries": ["L.scratchpad"],
-        "plugins": ["http://localhost:8000/attackgraphs.js"],
+        "plugins": ["plugins/attackgraphs.js"],
         "recentColors": [],
         "formatWidth": "240",
         "createTarget": false,


### PR DESCRIPTION
This PR updates the test environment to use a docker container with a self-built docker image to run the Playwright tests against. Doing so lowers the risk of unknown updates to draw.io that makes any of the tests fail.