### PR TITLE
Add a Changelog and start versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+## 1.1.0 - 2022-11-20
+
+Start of this changelog, which is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This version contains several backwards compatible new features and bug fixes. The versioning of the attack graphs plugin will adhere to [Semantic Versioning](https://semver.org/) beginning with this version.
+
+### Added
+
+- CHANGELOG.md (this file) to keep record of future changes to the plugin
+- Semantic versioning ([SemVer](https://semver.org/)) starting with this release
+- Version of the plugin shown in the `Attack Graphs` menu (together with the current hash)
+- Ordering of default attributes can be changed in the `Default Attributes...` dialog
+- Default **aggregation function** can be set individually for every attack graph node type
+- Default **computed attributes function** can be set individually for every attack graph node type
+- Bubble color can be set by computed attributes functions
+- Highlight incoming and outgoing edges of a selected attack graph node
+- Highlight critical paths
+- Progress bar showing whether background worker are still evaluating the graph
+- `Set attackgraph shape` context menu item to convert selected nodes to attack graph nodes
+
+### Fixes and Improvements
+
+- Resizing and moving nodes is faster even in larger graphs (in the order of milliseconds)
+- Default attributes are displayed in nodes in the same order as they appear in the `Default Attributes...` dialog
+- Playwright tests use a Docker container with the web version of draw.io.
+- Improved `npm run` scripts
+- Nodes do not disappear anymore if attributes have an empty value
+- AND and OR nodes are labeled by default
+- Allow for non-integer edge weights
+
+### Removed
+
+- `Enable Sensitivity Analysis` menu item from the `Attack Graphs` menu
+- Default attributes are not added to white attack step nodes when adding them from the Sidebar.
+
+## 1.0.0 - 2022-02-07
+
+First release of the Attack Graphs Plugin for draw.io.
+
+### Added
+
+- Shapes for different attack graph node types (Consequence, Attack Step, Security Measure, AND, OR)
+- Icon legend listing default attributes together with their icon
+- Computed attributes functions
+- Aggregation functions
+- Sensitivity Analysis
+- Dialogs for setting the aggregation function and computed attributes function for individual attack graph nodes
+- Global dialog to add, edit, and delete default attributes, aggregation functions, and computed attributes functions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "drawio-plugin-attackgraphs",
-  "version": "1.0.0",
-  "description": "",
+  "version": "1.1.0",
+  "description": "An Attack Graphs Extension for Draw.io",
   "main": "index.js",
   "private": true,
   "scripts": {

--- a/src/Resources.ts
+++ b/src/Resources.ts
@@ -1,4 +1,5 @@
 declare const __COMMIT_HASH__: string;
+declare const __VERSION__: string;
 
 export class Resources {
   static register(lang: string): void {
@@ -49,7 +50,7 @@ attackGraphs.custom=Custom
 attackGraphs.mustAssignMaxValue=You have to set the max value for
 attackGraphs.setDefaultAttributes=Set default attributes for selection
 attackGraphs.setAttackGraphShape=Set selection as attackgraph nodes
-attackGraphs.showVersion=Version ${__COMMIT_HASH__}
+attackGraphs.showVersion=Version ${__VERSION__} (${__COMMIT_HASH__})
 attackGraphs.enableSensitivityAnalysis=Enable Sensitivity Analysis
 attackGraphs.applySensitivityAnalysis=Apply Sensitivity Analysis
 attackGraphs.value=Value
@@ -100,7 +101,7 @@ attackGraphs.custom=Benutzerdefiniert
 attackGraphs.mustAssignMaxValue=Sie müssen einen Maximalwert setzen für
 attackGraphs.setDefaultAttributes=Setze Standardattribute für Auswahl
 attackGraphs.setAttackGraphShape=Markiere Auswahl als Attack Graph Knoten
-attackGraphs.showVersion=Version ${__COMMIT_HASH__}
+attackGraphs.showVersion=Version ${__VERSION__} (${__COMMIT_HASH__})
 attackGraphs.enableSensitivityAnalysis=Sensitivitätsanalyse aktivieren
 attackGraphs.applySensitivityAnalysis=Sensitivitätsanalyse anwenden
 attackGraphs.value=Wert

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const version = require('./package.json').version;
 const webpack = require('webpack');
 const CopyPlugin = require('copy-webpack-plugin');
 
@@ -12,7 +13,8 @@ module.exports = {
   devtool: 'source-map',
   plugins: [
     new webpack.DefinePlugin({
-      __COMMIT_HASH__: JSON.stringify(commitHash)
+      __COMMIT_HASH__: JSON.stringify(commitHash),
+      __VERSION__: JSON.stringify(version)
     }),
     new CopyPlugin({
       patterns: [


### PR DESCRIPTION
This PR introduces a Changelog which keeps a record of all changes made to the attack graphs plugin. Because many changes where introduced since the initial commit, this PR will increase the version from 1.0.0 to 1.1.0.

The plugin will use semantic versioning ([SemVer](https://semver.org/)) starting with the version 1.1.0 of the plugin.

Closes #85.