### PR TITLE
Fix issue with changed sidebar structure

### DIFF
--- a/src/Sidebar.ts
+++ b/src/Sidebar.ts
@@ -245,17 +245,19 @@ export class Sidebar {
     }
 
     // Collapses default sidebar entry and inserts this before
-    const c = this.sidebar?.container;
+    /*const c = this.sidebar?.container;
     if (c && c.firstChild && c.lastChild) {
       (c.firstChild as HTMLElement).click();
       c.insertBefore(c.lastChild, c.firstChild);
       c.insertBefore(c.lastChild, c.firstChild);
-    }
+    }*/
 
   }
 
   updatePalette(): void {
-    this.sidebar?.removePalette('AttackGraphs');
-    this.addPalette();
+    if (this.ui) {
+      this.ui.removeLibrarySidebar('AttackGraphs');
+      this.addPalette();
+    }
   }
 }

--- a/src/Sidebar.ts
+++ b/src/Sidebar.ts
@@ -245,13 +245,20 @@ export class Sidebar {
     }
 
     // Collapses default sidebar entry and inserts this before
-    /*const c = this.sidebar?.container;
-    if (c && c.firstChild && c.lastChild) {
-      (c.firstChild as HTMLElement).click();
-      c.insertBefore(c.lastChild, c.firstChild);
-      c.insertBefore(c.lastChild, c.firstChild);
-    }*/
+    if (this.sidebar) {
+      let c = this.sidebar.container;
 
+      // draw.io >= 20.6.0: Sidebar structure changed and now has a footer in it...
+      if (this.sidebar.container.getElementsByClassName('geSidebarFooter').length > 0 && c.firstChild) {
+        c = c.firstChild as HTMLElement;
+      }
+
+      if (c && c.firstChild && c.lastChild) {
+        (c.firstChild as HTMLElement).click();
+        c.insertBefore(c.lastChild, c.firstChild);
+        c.insertBefore(c.lastChild, c.firstChild);
+      }
+    }
   }
 
   updatePalette(): void {

--- a/types/drawio/index.d.ts
+++ b/types/drawio/index.d.ts
@@ -22,6 +22,7 @@ declare namespace Draw {
     showDialog(elt, w, h, modal, closable, onClose?, noScroll?, transparent?, onResize?, ignoreBgClick?);
     confirm(msg: string, okFn: () => void, cancelFn?: () => void, okLabel?: string, cancelLabel?: string, closable?: boolean): void;
     hideDialog();
+    removeLibrarySidebar(id: string);
   }
 
   class DiagramPage {
@@ -115,8 +116,8 @@ declare namespace Draw {
   class Sidebar {
     container: HTMLElement;
     createVertexTemplate(style: string, width: number, height: number, value?: any, title?: string, showLabel?: boolean, showTitle?: boolean, allowCellsInserted?: boolean, showTooltip?: boolean): HTMLAnchorElement;
-    addPalette(arg0: string, arg1: string, arg2: boolean, arg3: (content: HTMLDivElement, title: HTMLAnchorElement) => void);
-    removePalette(id: string);
+    addPalette(id: string, title: string, expanded: boolean, onInit: (content: HTMLDivElement, title?: HTMLAnchorElement) => void);
+    //removePalette(id: string); // Buggy
     updatePalette();
   }
 


### PR DESCRIPTION
This PR introduces a check whether the new sidebar structure of draw.io >= 20.6.0 is used or the old one. Depending on this, the right container encompassing the `Attack Graphs` palette is selected.

Fixes #99.