### PR TITLE
Enhance recalculation of cell values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/compare/v1.2.2...HEAD)
+
+### Fixes and Improvements
+
+- Enhance recalculation of cell values ([#108](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/issues/108))
+  - Avoid recaluclating the values of cells more than once
+  - Allow to specify several cells to simultaneously update within one function call
+
 ## [1.2.2](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/compare/v1.2.1...v1.2.2) - 2023-03-20
 
 ### Fixes and Improvements

--- a/src/AttributeRenderer.ts
+++ b/src/AttributeRenderer.ts
@@ -215,7 +215,8 @@ export class AttributeRenderer {
     promises: {[id: string]: Promise<void>}
   ): Promise<void> {
     // Wait for all childs
-    const outgoingEdges = cell.edges?.filter(x => x.source === cell && x.target) || [];
+    const childs = structure[cell.id];
+    const outgoingEdges = cell.edges?.filter(x => x.source === cell && x.target && childs.includes(x.target.id)) || [];
     await Promise.all(outgoingEdges.map(x => {
       // Only act if the cell is not process by anybody yet
       if (!Object.prototype.hasOwnProperty.call(promises, x.target.id)) {

--- a/src/VertexHandler.ts
+++ b/src/VertexHandler.ts
@@ -90,7 +90,7 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
       dlg.init();
       void (async () => {
         if (await dlg.show()) {
-          await AttributeRenderer.refreshCellValuesUpwards(cell.cell, ui, worker);
+          await AttributeRenderer.refreshCellValuesUpwards([cell.cell], ui, worker);
           await ui.editor.graph.refresh();
         }
       })();
@@ -102,7 +102,7 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
       dlg.init();
       void (async () => {
         if (await dlg.show()) {
-          await AttributeRenderer.refreshCellValuesUpwards(cell.cell, ui, worker);
+          await AttributeRenderer.refreshCellValuesUpwards([cell.cell], ui, worker);
           await ui.editor.graph.refresh();
         }
       })();


### PR DESCRIPTION
Instead of starting a calculation at every node in the `AttributeRendere.recalculateAllCells()` method, first create an update structure. This structure indicates for every cell affected by an update of a list of cells, for which child cells it must wait before it can calculate its own values. This allows to calculate cell values only once. They are correct because all child values are consistent before calculating the new values.

In the second step, the algorithm starts at the top level cells affected by the update that have no parents (incoming edges) themselves. The update structure is then used to wait for all child cells and calculate the cell's own values afterward.

Fixes #108.