### PR TITLE
Trigger graph updates also after undos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes and Improvements
 
+- Undos sometimes did not trigger recalculations of cell values ([#109](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/issues/109))
 - Enhance recalculation of cell values ([#108](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/issues/108))
   - Avoid recaluclating the values of cells more than once
   - Allow to specify several cells to simultaneously update within one function call

--- a/types/drawio/index.d.ts
+++ b/types/drawio/index.d.ts
@@ -165,6 +165,7 @@ class mxTerminalChange {
   previous: import('mxgraph').mxCell;
 }
 class mxChildChange {
+  child: import('mxgraph').mxCell;
   parent: import('mxgraph').mxCell;
   terminal: import('mxgraph').mxCell;
   previous: import('mxgraph').mxCell;


### PR DESCRIPTION
Remove listeners for `mxEvent.CELLS_ADDED` and `mxEvent.CELLS_REMOVED` events.

Instead use `mxEvent.CHANGE` event to react to cell removals and insertions. Using those, removals and insertions of cells via undos and redos are also catched.

Fixes #109.