### PR TITLE
Handle visibility of function handles correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enhance recalculation of cell values ([#108](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/issues/108))
   - Avoid recaluclating the values of cells more than once
   - Allow to specify several cells to simultaneously update within one function call
+- Function handles (aggregation and computed attributes functions) are shown after resizing nodes ([#115](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/issues/115))
 
 ## [1.2.2](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/compare/v1.2.1...v1.2.2) - 2023-03-20
 

--- a/src/VertexHandler.ts
+++ b/src/VertexHandler.ts
@@ -12,6 +12,7 @@ const IMAGE_HEIGHT = 24;
 class VertexHandler extends mxVertexHandler {
   functionHandles: HTMLImageElement[] | null = null;
   tooltipHandle: TooltipHandle | null = null;
+  handlesVisible = true;
 }
 class TooltipHandle {
   private width: number;
@@ -163,6 +164,7 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
     if (this.tooltipHandle) {
       this.tooltipHandle.redraw(b);
       this.tooltipHandle.getHandle().style.display = this.graph.getSelectionCount() === 1 ? '' : 'none';
+      this.tooltipHandle.getHandle().style.visibility = (this.handlesVisible) ? '' : 'hidden';
     }
 
     if (this.functionHandles) {
@@ -184,6 +186,7 @@ export const installVertexHandler = (ui: Draw.UI, worker: AsyncWorker): void => 
         for (const functionHandle of this.functionHandles) {
           // Shows function handles only if one vertex is selected
           functionHandle.style.display = this.graph.getSelectionCount() === 1 ? '' : 'none';
+          functionHandle.style.visibility = (this.handlesVisible) ? '' : 'hidden';
         }
       }
     }


### PR DESCRIPTION
Use `mxVertexHandler.handlesVisible` to decide on whether to show or hide function handles

Fixes #115.