### PR TITLE
Sensitivity analysis tests occasionally fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   - Allow to specify several cells to simultaneously update within one function call
 - Function handles (aggregation and computed attributes functions) are shown after resizing nodes ([#115](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/issues/115))
 
+### Internals
+
+- Fix: Sensitivity analysis test cases occasionally fail ([#111](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/issues/111))
+
 ## [1.2.2](https://github.com/INCYDE-GmbH/drawio-plugin-attackgraphs/compare/v1.2.1...v1.2.2) - 2023-03-20
 
 ### Fixes and Improvements

--- a/tests/attributes.spec.ts
+++ b/tests/attributes.spec.ts
@@ -153,18 +153,18 @@ test.describe('attributes and default attributes', () => {
 
     await page.locator('table.properties').locator('tr').locator('td').locator('span').click();
     const icon = page.locator('tbody').locator('tr').last().locator('td').last();
-    icon.click();
-    const path = await icon.locator('path').getAttribute('d');
+    await icon.click();
+    const path = await icon.locator('path').getAttribute('d') || '';
 
     await page.locator('.geDialog').last().locator('text=Apply').click();
     await page.locator('.geDialog').last().locator('text=Apply').click();
     // First activity vertex (white node) shall not have default attributes
     await page.locator('.geSidebarContainer').locator('text=Attack Step').nth(2).click();
     const href = await page.locator('.geDiagramContainer').locator('text=Attack Step')
-      .locator('xpath=..').locator('xpath=..').locator('xpath=..').locator('image').getAttribute('xlink:href');
+      .locator('xpath=..').locator('xpath=..').locator('xpath=..').locator('image').getAttribute('xlink:href') || '';
 
     const regex = RegExp(path, 'gm');
-    const result = regex.exec(href);
+    const result = regex.exec(href) || '';
     expect(result.length).toBeGreaterThan(0);
   });
 
@@ -177,7 +177,7 @@ test.describe('attributes and default attributes', () => {
 
     await page.locator('table.properties').locator('tr').locator('td').locator('span').click();
     const icon2 = await page.locator('tbody').locator('tr').last().locator('td').last();
-    icon2.click();
+    await icon2.click();
     const path = await icon2.locator('path').getAttribute('d');
     await drawio.applyDialog();
     expect(path).toEqual(await page.locator('td[name="icon_picker"]').locator('path').getAttribute('d'));
@@ -198,18 +198,18 @@ test.describe('attributes and default attributes', () => {
 
     await page.locator('table.properties').locator('tr').locator('td').locator('span').click();
     const icon = page.locator('tbody').locator('tr').last().locator('td').last();
-    icon.click();
-    const path = await icon.locator('path').getAttribute('d');
+    await icon.click();
+    const path = await icon.locator('path').getAttribute('d') || '';
 
     await drawio.applyDialog();
     await drawio.applyDialog();
 
     await drawio.addActivityNode();
     const href = await page.locator('.geDiagramContainer').locator('text=Attack Step')
-      .locator('xpath=..').locator('xpath=..').locator('xpath=..').locator('image').first().getAttribute('xlink:href');
+      .locator('xpath=..').locator('xpath=..').locator('xpath=..').locator('image').first().getAttribute('xlink:href') || '';
 
     const regex = RegExp(path, 'gm');
-    const result = regex.exec(href);
+    const result = regex.exec(href) || '';
     expect(result.length).toBeGreaterThan(0);
   });
 

--- a/tests/drawio-page.ts
+++ b/tests/drawio-page.ts
@@ -144,7 +144,7 @@ export class DrawioPage {
   }
 
   async expectSensitivityAnalysisDisabled() {
-    this.page.waitForSelector('#ag_enableSensitivityAnalysis', { state: 'attached' });
+    await this.page.locator('#ag_enableSensitivityAnalysis').waitFor({state: 'visible'});
   }
 
   async loadGraph(graph: string) {


### PR DESCRIPTION
Use a different waiting routine `locator().waitFor()` to wait for the sensitivity analysis to be disabled.

Fixes #111.